### PR TITLE
Clean up stdout when it includes \r in its payload

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -2,6 +2,7 @@ package daap
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -93,8 +94,11 @@ func (c *Container) stream(ctx context.Context, hijacked types.HijackedResponse,
 			b, err := buf.ReadBytes('\n')
 			// If raw bytes doesn't have header, use previous io type as a default.
 			if err == nil {
-				payload = CreatePayloadFromRawBytes(payload.Type, b)
-				stream <- payload
+				// TODO: might need to adjust more patterns
+				for _, line := range bytes.Split(b, []byte("\r")) {
+					payload = CreatePayloadFromRawBytes(payload.Type, line)
+					stream <- payload
+				}
 			} else {
 				if err != io.EOF {
 					log.Println("Buffer Error:", err)


### PR DESCRIPTION
Fix https://github.com/otiai10/awsub/issues/17